### PR TITLE
[bugfix] window 경로 구분자로 인한 에러 수정

### DIFF
--- a/SuperUXConverter/extractor/file-content.ts
+++ b/SuperUXConverter/extractor/file-content.ts
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { splitPath } from '../parser/utils';
+import { joinPath, splitPath } from '../parser/utils';
 
 export const getFileContent = (filePath: string): Promise<string> => {
     return fs.promises.readFile(filePath, { encoding: 'utf8' });
@@ -10,9 +10,10 @@ export const generateFileContent = async (filePath: string, fileContent: string)
     try {
         await fs.promises.access(filePath); // 파일 존재 여부 확인
     } catch (error) {
+        // @ts-ignore
         if (error.code === 'ENOENT') {
             // ENOENT 오류가 발생하면 파일이 존재하지 않는 것이므로 폴더 생성
-            const folderPath = splitPath(filePath).slice(0, -1).join('/');
+            const folderPath = joinPath(splitPath(filePath).slice(0, -1));
             await fs.promises.mkdir(folderPath, { recursive: true });
         } else {
             console.error('오류 발생:', error);

--- a/SuperUXConverter/extractor/index.ts
+++ b/SuperUXConverter/extractor/index.ts
@@ -46,7 +46,6 @@ export const generateSuperUXFiles = (targetFilePath: string, resultFolderPath: s
     });
 
     extractMetaInfos(targetFilePath).then(({ typeInfos, eventInfos }) => {
-        console.log({ typeInfos, eventInfos });
         generateCustomComponentMetaDataFile(typeInfos, eventInfos, resultMetaDataFilePath);
     });
 };

--- a/SuperUXConverter/index.ts
+++ b/SuperUXConverter/index.ts
@@ -1,15 +1,16 @@
 import fs from 'fs';
 import path from 'path';
-import { splitPath } from './parser/utils';
+import { joinPath, resolvePath, splitPath } from './parser/utils';
 import { generateSuperUXFiles } from './extractor';
 
 const [componentFilePath] = process.argv.slice(2);
+const resolvedComponentFilePath = componentFilePath && resolvePath(componentFilePath);
 const resultFileBasePath = 'SuperUXCustomComponent';
 
 const generateSuperUXComponentRecursively = async (fileOrFolderPath, resultPath) => {
     try {
         if (fileOrFolderPath.endsWith('.tsx')) {
-            const resultFilePath = splitPath(resultPath).slice(0, -1).join('/');
+            const resultFilePath = joinPath(splitPath(resultPath).slice(0, -1));
             generateSuperUXFiles(fileOrFolderPath, resultFilePath);
             return;
         }
@@ -28,18 +29,18 @@ const generateSuperUXComponentRecursively = async (fileOrFolderPath, resultPath)
 };
 
 (() => {
-    if (componentFilePath === undefined) {
+    if (resolvedComponentFilePath === undefined) {
         console.error('첫 번째 인자에 변환 대상 컴포넌트 경로가 입력되지 않았습니다.');
         return;
     }
 
-    if (fs.existsSync(componentFilePath) === false) {
+    if (fs.existsSync(resolvedComponentFilePath) === false) {
         console.error('해당 경로에 대상 파일이 존재하지 않습니다.');
         return;
     }
 
-    const paths = splitPath(componentFilePath);
+    const paths = splitPath(resolvedComponentFilePath);
     const restResultPath = !paths[0].startsWith('.') ? paths.slice(1) : paths.slice(2);
 
-    generateSuperUXComponentRecursively(componentFilePath, path.join(resultFileBasePath, ...restResultPath));
+    generateSuperUXComponentRecursively(resolvedComponentFilePath, path.join(resultFileBasePath, ...restResultPath));
 })();

--- a/SuperUXConverter/parser/utils.ts
+++ b/SuperUXConverter/parser/utils.ts
@@ -1,6 +1,8 @@
 import ts from 'typescript';
 import os from 'os';
 
+const platform = os.platform();
+
 export const getNodeName = (node: ts.Node) => {
     // @ts-ignore
     const name = node.name?.escapedText || node.text;
@@ -8,8 +10,6 @@ export const getNodeName = (node: ts.Node) => {
 };
 
 export const splitPath = (target: string) => {
-    const platform = os.platform();
-
     if (platform === 'darwin') {
         // mac
         return target.split('/');
@@ -17,7 +17,35 @@ export const splitPath = (target: string) => {
 
     if (platform === 'win32') {
         // window
-        return target.split('\\');
+        return target.replace(/\\\\/g, '\\').split('\\');
+    }
+
+    throw new Error('지원하지 않는 os입니다.');
+};
+
+export const joinPath = (target: string[]) => {
+    if (platform === 'darwin') {
+        // mac
+        return target.join('/');
+    }
+
+    if (platform === 'win32') {
+        // window
+        return target.join('\\');
+    }
+
+    throw new Error('지원하지 않는 os입니다.');
+};
+
+export const resolvePath = (target: string) => {
+    if (platform === 'darwin') {
+        // mac
+        return target;
+    }
+
+    if (platform === 'win32') {
+        // window
+        return target.replace(/\//g, '\\');
     }
 
     throw new Error('지원하지 않는 os입니다.');


### PR DESCRIPTION
## 해결한 이슈
window에서 경로 구분자를 '\\' 로 사용하기 때문에 발생하는 이슈 해결

## 이슈 해결 방법
- os에 따라 split 구분자가 달라지도록 `splitPath` util 함수 생성
- os에 따라 join 구분자가 달라지도록 `joinPath` util 함수 생성
- window환경에서 초기 입력된 경로가 path/to/file 처럼 '/'로 구분되었을 경우 '\\'로 replace하도록 `resolvePath` util 함수 생성